### PR TITLE
Added notes and changed default deadzones

### DIFF
--- a/DualShock2.ini
+++ b/DualShock2.ini
@@ -1,6 +1,9 @@
-//DualShock 1&2 Adapter
+//DualShock 1&2 Adapter (Dual-slot Version)
+//This INI file assumes that you have the controller plugged into the rightmost slot of the adapter and that Analog mode is turned on.
+//Be sure to allow the game to fully boot up before plugging in the adapter.
+//In the case of Smash for Wii U (and possibly a lot of other games), periodically make sure that Analog Mode is turned on.
 [vid=0x0810,pid=0x0001]
-//Slot Selection (for Dual/Quad adapters)
+//Slot Selection (Because it's a Dual-slot Adapter)
 Input_Filter=0x00,0x01
 //Buttons
 VPad_Button_A=0x05,0x20
@@ -32,17 +35,21 @@ VPad_Button_DPad_Neutral=0x05,0x0F
 //Thumbsticks
 VPad_L_Stick_X=0x03,0x80
 VPad_L_Stick_X_MinMax=0x00,0xFF
-VPad_L_Stick_X_Deadzone=0x33
+VPad_L_Stick_X_Deadzone=0x0A
+//VPad_L_Stick_X_Deadzone=0x33
 VPad_L_Stick_X_Invert=False
 VPad_L_Stick_Y=0x04,0x80
 VPad_L_Stick_Y_MinMax=0x00,0xFF
-VPad_L_Stick_Y_Deadzone=0x24
+VPad_L_Stick_Y_Deadzone=0x0A
+//VPad_L_Stick_Y_Deadzone=0x24
 VPad_L_Stick_Y_Invert=True
 VPad_R_Stick_X=0x02,0x80
 VPad_R_Stick_X_MinMax=0x00,0xFF
-VPad_R_Stick_X_Deadzone=0x24
+VPad_R_Stick_X_Deadzone=0x0A
+//VPad_R_Stick_X_Deadzone=0x24
 VPad_R_Stick_X_Invert=False
 VPad_R_Stick_Y=0x01,0x80
 VPad_R_Stick_Y_MinMax=0x00,0xFF
-VPad_R_Stick_Y_Deadzone=0x26
+VPad_R_Stick_Y_Deadzone=0x0A
+//VPad_R_Stick_Y_Deadzone=0x26
 VPad_R_Stick_Y_Invert=True


### PR DESCRIPTION
The Deadzones were adjusted to be attuned to brand new controllers.
Notes on how to get the adapter not to crash the Wii U while using HID_to_VPad.
