### PR TITLE
Create MAYFLASH_N64_Controller_Adapter_for_PC_USB.ini

### DIFF
--- a/MAYFLASH_N64_Controller_Adapter_for_PC_USB.ini
+++ b/MAYFLASH_N64_Controller_Adapter_for_PC_USB.ini
@@ -1,0 +1,47 @@
+//MAYFLASH N64 Controller Adapter for PC USB
+//UPC 6903368296105
+[vid=0x0E8F,pid=0x3013]
+
+//Using Port 1 (Right slot)
+INPUT_FILTER                =   0x00,0x01
+
+//DPad
+//Values stored in 0x05 and 0x07, last part of both bytes.
+//First part of 0x05 stores A and B keys. Using 0x05.  
+DPAD_MODE                   =   DPAD_HAT
+DPAD_MASK                   =   0x0F
+VPAD_BUTTON_DPAD_N          =   0x05,0x00
+VPAD_BUTTON_DPAD_NE         =   0x05,0x01
+VPAD_BUTTON_DPAD_E          =   0x05,0x02
+VPAD_BUTTON_DPAD_SE         =   0x05,0x03
+VPAD_BUTTON_DPAD_S          =   0x05,0x04
+VPAD_BUTTON_DPAD_SW         =   0x05,0x05
+VPAD_BUTTON_DPAD_W          =   0x05,0x06
+VPAD_BUTTON_DPAD_NW         =   0x05,0x07
+VPAD_BUTTON_DPAD_Neutral    =   0x05,0x0F
+
+//Buttons (A, B, Start)
+VPAD_BUTTON_A               =   0x05,0x20
+VPAD_BUTTON_B               =   0x05,0x40
+VPAD_BUTTON_PLUS            =   0x06,0x20
+
+//Triggers (L, R, Z)
+VPAD_BUTTON_L               =   0x06,0x04
+VPAD_BUTTON_R               =   0x06,0x08
+VPAD_BUTTON_ZL              =   0x06,0x10
+
+//Analog Stick
+//MinMax measured using both Gray and Purple official controllers. Moderate wear.
+VPad_L_Stick_X              =   0x03,0x80
+VPad_L_Stick_X_MinMax       =   0x30,0xC7
+VPad_L_Stick_Y              =   0x04,0x80
+VPad_L_Stick_Y_MinMax       =   0x32,0xCC
+VPad_L_Stick_Y_Invert       =   True
+
+//C Buttons
+VPad_R_Stick_X              =   0x02,0x80
+VPad_R_Stick_X_MinMax       =   0xE0,0x20
+VPad_R_Stick_X_Invert       =   true
+VPad_R_Stick_Y              =   0x01,0x80
+VPad_R_Stick_Y_MinMax       =   0xE0,0x20
+VPad_R_Stick_Y_Invert       =   true


### PR DESCRIPTION
Configuration file for MAYFLASH N64 twin USB adapter
