### PR TITLE
Fixes in config

### DIFF
--- a/MAYFLASH_N64_Controller_Adapter_for_PC_USB.ini
+++ b/MAYFLASH_N64_Controller_Adapter_for_PC_USB.ini
@@ -3,7 +3,8 @@
 [vid=0x0E8F,pid=0x3013]
 
 //Using Port 1 (Right slot)
-INPUT_FILTER                =   0x00,0x01
+PAD1_FILTER=0x00,0x01
+PAD2_FILTER=0x00,0x02
 
 //DPad
 //Values stored in 0x05 and 0x07, last part of both bytes.
@@ -40,8 +41,10 @@ VPad_L_Stick_Y_Invert       =   True
 
 //C Buttons
 VPad_R_Stick_X              =   0x02,0x80
-VPad_R_Stick_X_MinMax       =   0xE0,0x20
+VPad_R_Stick_X_MinMax       =   0x20,0xE0
 VPad_R_Stick_X_Invert       =   true
 VPad_R_Stick_Y              =   0x01,0x80
-VPad_R_Stick_Y_MinMax       =   0xE0,0x20
+VPad_R_Stick_Y_MinMax       =   0x20,0xE0
 VPad_R_Stick_Y_Invert       =   true
+
+PAD_COUNT=2


### PR DESCRIPTION
There was an error setting for C buttons resulting in always having pressed the left and down C buttons. This was because the Min and Max values were inverted.
I added support for 2 controllers and tested them.