### PR TITLE
Create proexps3.ini

### DIFF
--- a/proexps3.ini
+++ b/proexps3.ini
@@ -1,0 +1,52 @@
+//Power A Pro EX PS3
+[vid=0x20d6,pid=0xca6d]
+
+VPAD_BUTTON_A               = 0x00,0x04
+VPAD_BUTTON_B               = 0x00,0x02
+VPAD_BUTTON_X               = 0x00,0x08
+VPAD_BUTTON_Y               = 0x00,0x01
+
+VPAD_BUTTON_PLUS            = 0x01,0x02
+VPAD_BUTTON_MINUS           = 0x01,0x01
+VPAD_BUTTON_HOME          = 0x01,0x10
+
+VPAD_BUTTON_L               = 0x00,0x10
+VPAD_BUTTON_R               = 0x00,0x20
+
+VPAD_BUTTON_STICK_L         = 0x01,0x04
+VPAD_BUTTON_STICK_R         = 0x01,0x08
+
+VPAD_BUTTON_ZL              = 0x00,0x40
+VPAD_BUTTON_ZR              = 0x00,0x80
+
+DPAD_MODE = DPAD_HAT
+DPad_MASK = 0x0F
+VPAD_BUTTON_DPAD_N          = 0x02,0x00
+VPAD_BUTTON_DPAD_NE         = 0x02,0x01
+VPAD_BUTTON_DPAD_E          = 0x02,0x02
+VPAD_BUTTON_DPAD_SE         = 0x02,0x03
+VPAD_BUTTON_DPAD_S          = 0x02,0x04
+VPAD_BUTTON_DPAD_SW         = 0x02,0x05
+VPAD_BUTTON_DPAD_W          = 0x02,0x06
+VPAD_BUTTON_DPAD_NW         = 0x02,0x07
+VPAD_BUTTON_DPAD_Neutral    = 0x02,0x0F
+
+VPAD_L_STICK_X              = 0x03,0x81
+VPAD_L_STICK_X_MINMAX       = 0x00,0xFF
+VPAD_L_STICK_X_DEADZONE     = 0x04
+
+VPAD_L_STICK_Y              = 0x04,0x7C
+VPAD_L_STICK_Y_MINMAX       = 0x00,0xFF
+VPAD_L_STICK_Y_DEADZONE     = 0x05
+VPad_L_Stick_Y_Invert       = true
+
+VPAD_R_STICK_X              = 0x05,0x78
+VPAD_R_STICK_X_MINMAX       = 0x00,0xFF
+VPAD_R_STICK_X_DEADZONE     = 0x05
+
+VPAD_R_STICK_Y              = 0x06,0x8A
+VPAD_R_STICK_Y_MINMAX       = 0x00,0xFF
+VPAD_R_STICK_Y_DEADZONE     = 0x05
+VPad_R_Stick_Y_Invert       = true
+
+PAD_COUNT=1


### PR DESCRIPTION
Allows the Power A Pro EX PS3 wired controller to be used on Wii U.