### PR TITLE
Add stick clicks for Horipad

### DIFF
--- a/Horipad Switch.ini
+++ b/Horipad Switch.ini
@@ -30,6 +30,9 @@ VPAD_BUTTON_ZL			=	0x00,	0x40
 VPAD_BUTTON_ZR			=	0x00,	0x80
 
 //Sticks
+VPAD_BUTTON_STICK_L	= 0x01,0x04
+VPAD_BUTTON_STICK_R	= 0x01,0x08
+
 VPad_L_Stick_X          =   0x03,0x80 
 VPad_L_Stick_X_MinMax   =   0x00,0xFF 
 VPad_L_Stick_X_Deadzone =   0x0A     


### PR DESCRIPTION
This config was missing the stick clicks / L3/R3. I found the values using HID Test, and they are the same as those given for Core(plus) / PowerA. I have added them in the Sticks section.