### PR TITLE
PowerA Gamecube Wired Controller

### DIFF
--- a/powera_gc_wired.ini
+++ b/powera_gc_wired.ini
@@ -1,0 +1,58 @@
+[vid=0x20d6,pid=0xa711]
+[IgnoreDefault]
+//DPAD
+DPAD_MODE                   =   DPAD_HAT
+DPAD_MASK                   =   0x0F
+
+VPAD_BUTTON_DPAD_NETURAL    =   0x02,   0x0F
+VPAD_BUTTON_DPAD_N          =   0x02,   0x00
+VPAD_BUTTON_DPAD_NE         =   0x02,   0x01
+VPAD_BUTTON_DPAD_E          =   0x02,   0x02
+VPAD_BUTTON_DPAD_SE         =   0x02,   0x03
+VPAD_BUTTON_DPAD_S          =   0x02,   0x04
+VPAD_BUTTON_DPAD_SW         =   0x02,   0x05
+VPAD_BUTTON_DPAD_W          =   0x02,   0x06
+VPAD_BUTTON_DPAD_NW         =   0x02,   0x07
+
+//FACE-BUTTONS
+VPAD_BUTTON_Y               =   0x00,   0x01    //SQUARE
+VPAD_BUTTON_X               =   0x00,   0x08
+VPAD_BUTTON_B               =   0x00,   0x02
+VPAD_BUTTON_A               =   0x00,   0x04
+
+//SHOULDER-BUTTONS
+
+VPAD_BUTTON_R               =   0x00,   0x20
+VPAD_BUTTON_ZR              =   0x00,   0x80
+
+VPAD_BUTTON_L               =   0x00,   0x10 //also 0x00, 0xA0
+VPAD_BUTTON_ZL              =   0x00,   0x40
+
+//OTHER-BUTTONS
+VPAD_BUTTON_STICK_L         =   0x01,   0x04
+VPAD_BUTTON_STICK_R         =   0x01,   0x08
+
+//LEFT-STICK
+VPAD_L_STICK_X              =   0x03,   0x80
+VPAD_L_STICK_Y              =   0x04,   0x80
+
+VPAD_L_STICK_X_MINMAX       =   0x03,   0xFF
+VPAD_L_STICK_Y_MINMAX       =   0x04,   0xFF
+
+VPAD_L_STICK_Y_INVERT       =   TRUE
+
+//RIGHT-STICK
+
+VPAD_R_STICK_X              =   0x05,   0x80
+VPAD_R_STICK_Y              =   0x06,   0x80
+
+VPAD_R_STICK_X_MINMAX       =   0x05,   0xFF
+VPAD_R_STICK_Y_MINMAX       =   0x06,   0xFF
+
+VPAD_R_STICK_Y_INVERT       =   TRUE
+
+//MISC
+VPAD_BUTTON_PLUS            =   0x01,   0x02
+VPAD_BUTTON_MINUS           =   0x01,   0x01
+VPAD_BUTTON_HOME            =   0x01,   0x10
+PAD_COUNT                   =   0x01


### PR DESCRIPTION
This adds support for the PowerA Gamecube Wired Controller for Nintendo Switch (to be used for the WiiU).