### PR TITLE
Create Generic_N64_Controller_vid0810_pidE501.ini

### DIFF
--- a/Generic_N64_Controller_vid0810_pidE501.ini
+++ b/Generic_N64_Controller_vid0810_pidE501.ini
@@ -1,0 +1,44 @@
+[vid=0810,pid=E501]
+
+# Generic (whitelabel) USB N64 gamepad
+# this is a brandless N64 clone USB gamepad, the D-PAD and analog stick on this controller are sending the same values
+# This controller does not have support for rumble or any other packs, like the original did, neither does it have rumble support build in
+# https://nl.aliexpress.com/item//32837180455.html
+
+# This controller to function exactly like n64 controller in virtual console (just use default button layout!)
+
+VID=0810
+PID=E501
+
+# Buttons:
+# A / B / L / R buttons => mapped accordingly
+VPAD_BUTTON_A    = 0x06, 0x02
+VPAD_BUTTON_B    = 0x06, 0x01
+VPAD_BUTTON_L    = 0x06, 0x04
+VPAD_BUTTON_R    = 0x06, 0x08
+
+# Start button mapped to + button
+VPAD_BUTTON_PLUS = 0x06, 0x20
+
+# Z button => mapped to ZL button
+VPAD_BUTTON_ZL	 = 0x06, 0x10
+
+# D-PAD
+# To map Left stick to D-PAD enable 5 lines below (and disable D-PAD below that): (this is default for Virtual Console n64)
+VPAD_L_STICK_Y        = 0x04, 0x7F
+VPAD_L_STICK_Y_MINMAX = 0X00, 0XFF
+VPAD_L_STICK_Y_INVERT = TRUE
+VPAD_L_STICK_X        = 0x03, 0x7F
+VPAD_L_STICK_X_MINMAX = 0X00, 0XFF
+# To map d-pad to D-PAD enable 5 lines below (and disable 5 lines above):
+#DPAD_MODE                  =   DPAD_Absolute_2Values
+#VPAD_BUTTON_DPAD_ABS_UP    =   0x04, 0x00
+#VPAD_BUTTON_DPAD_ABS_DOWN  =   0x04, 0xFF
+#VPAD_BUTTON_DPAD_ABS_LEFT  =   0x03, 0x00
+#VPAD_BUTTON_DPAD_ABS_RIGHT =   0x03, 0xFF
+
+# C buttons => mapped to right stick
+VPAD_R_STICK_UP    = 0x05, 0x1F
+VPAD_R_STICK_DOWN  = 0x05, 0x4F
+VPAD_R_STICK_LEFT  = 0x05, 0x8F
+VPAD_R_STICK_RIGHT = 0x05, 0x2F


### PR DESCRIPTION
Added support for white label USB N64 clone.
https://nl.aliexpress.com/item//32837180455.html
Added config to swap the analog/dpad config.
Used Virtual console (wii u) default button layout to map the corresponding buttons.

C buttons => right analog stick
D-PAD / analog stick => left analog stick (and added example for mapping this to the d-pad)
A => A
B => B
START => +
L => L
R => R
Z => ZL