### PR TITLE
Adding support for PowerA Wired Controller (NS)

### DIFF
--- a/PowerA_Basic.ini
+++ b/PowerA_Basic.ini
@@ -1,0 +1,57 @@
+[vid=0x20d6,pid=0xa711]
+[IgnoreDefault] //Ignoring the built in default values
+VPAD_BUTTON_A               = 0x00,0x04
+VPAD_BUTTON_B               = 0x00,0x02
+VPAD_BUTTON_X               = 0x00,0x08
+VPAD_BUTTON_Y               = 0x00,0x01
+
+VPAD_BUTTON_PLUS            = 0x01,0x02
+VPAD_BUTTON_MINUS           = 0x01,0x01
+VPAD_BUTTON_HOME            = 0x01,0x10
+
+VPAD_BUTTON_L               = 0x00,0x10
+VPAD_BUTTON_R               = 0x00,0x20
+
+VPAD_BUTTON_STICK_L         = 0x01,0x04
+VPAD_BUTTON_STICK_R         = 0x01,0x08
+
+VPAD_BUTTON_ZL              = 0x00,0x40
+VPAD_BUTTON_ZR              = 0x00,0x80
+
+DPAD_MODE                   =   DPAD_HAT
+DPad_MASK                   =   0x0F
+
+VPAD_BUTTON_DPAD_N          =   0x02,0x00
+VPAD_BUTTON_DPAD_NE         =   0x02,0x01
+VPAD_BUTTON_DPAD_E          =   0x02,0x02
+VPAD_BUTTON_DPAD_SE         =   0x02,0x03
+VPAD_BUTTON_DPAD_S          =   0x02,0x04
+VPAD_BUTTON_DPAD_SW         =   0x02,0x05
+VPAD_BUTTON_DPAD_W          =   0x02,0x06
+VPAD_BUTTON_DPAD_NW         =   0x02,0x07
+VPAD_BUTTON_DPAD_Neutral    =   0x02,0x0F
+
+VPAD_L_STICK_X              = SWITCH_PRO_STICK_L_X
+VPAD_L_STICK_Y              = SWITCH_PRO_STICK_L_Y
+VPAD_R_STICK_X              = SWITCH_PRO_STICK_R_X
+VPAD_R_STICK_Y              = SWITCH_PRO_STICK_R_Y
+
+//Thumbsticks
+VPad_L_Stick_X          =   0x03,0x80 // postion: 0x03, neutral value: 0x80
+VPad_L_Stick_X_MinMax   =   0x00,0xFF // min value: 0x00, max value: 0xFF
+VPad_L_Stick_X_Deadzone =   0x0A      // deadzone: 0x0A
+
+VPad_L_Stick_Y          =   0x04,0x80 // postion: 0x04, neutral value: 0x80
+VPad_L_Stick_Y_MinMax   =   0x00,0xFF // min value: 0x00, max value: 0xFF
+VPad_L_Stick_Y_Deadzone =   0x0A      // deadzone: 0x0A
+
+VPad_R_Stick_X          =   0x05,0x80 // postion: 0x02, neutral value: 0x80
+VPad_R_Stick_X_MinMax   =   0x00,0xFF // min value: 0x00, max value: 0xFF
+VPad_R_Stick_X_Deadzone =   0x0A      // deadzone: 0x0A
+
+VPad_R_Stick_Y          =   0x06,0x80 // postion: 0x01, neutral value: 0x80
+VPad_R_Stick_Y_MinMax   =   0x00,0xFF // min value: 0x00, max value: 0xFF
+VPad_R_Stick_Y_Deadzone =   0x0A      // deadzone: 0x0A
+
+//This device is no adapter that can't have more than 1 pads.
+PAD_COUNT                   =   0x01


### PR DESCRIPTION
Providing controller link for reference:
https://www.powera.com/p/nintendo/nintendo-switch/controllers/wired/wired-controller-for-nintendo-switch-black-1511370-01/