### PR TITLE
Add Support for Hori Fighting Commander Pad

### DIFF
--- a/HoriFightingCommander.ini
+++ b/HoriFightingCommander.ini
@@ -1,0 +1,39 @@
+//Hori Fighting Commander was set to PS4 mode when testing, with L1-R1 and L2-R2 mode as well. This controller does not have sticks, so I did not include them in the config.
+//Note that Turbo does not work in my experience.
+
+//vid and pid
+[vid=0x0F0D,pid=0x0084]
+
+//Cross (or 'X') is A, Circle is B, Triangle is Y, Square is X. Adjust as you like! 
+
+VPAD_BUTTON_A       = 0x05,0x28
+VPAD_BUTTON_B       = 0x05,0x48
+VPAD_BUTTON_Y       = 0x05,0x88
+VPAD_BUTTON_X       = 0x05,0x18
+
+//Share is Minus, Options is Plus
+VPAD_BUTTON_PLUS    = 0x06,0x20
+VPAD_BUTTON_MINUS   = 0x06,0x10
+
+//L1 and R1 respectively. Can be swapped with L2/R2 if preferred.
+VPAD_BUTTON_L       = 0x06,0x01
+VPAD_BUTTON_R       = 0x06,0x02
+
+//L2 and R2 respectively. Can be swapped with L1/R1 if preferred.
+VPAD_Button_ZL      = 0x06, 0x04
+VPAD_Button_ZR      = 0x06, 0x08
+
+DPAD_MODE           = DPAD_HAT
+DPAD_MASK           = 0x0F
+
+VPAD_BUTTON_DPAD_N          =   0x05,0x00 
+VPAD_BUTTON_DPAD_NE         =   0x05,0x01 
+VPAD_BUTTON_DPAD_E          =   0x05,0x02
+VPAD_BUTTON_DPAD_SE         =   0x05,0x03
+VPAD_BUTTON_DPAD_S          =   0x05,0x04
+VPAD_BUTTON_DPAD_SW         =   0x05,0x05
+VPAD_BUTTON_DPAD_W          =   0x05,0x06
+VPAD_BUTTON_DPAD_NW         =   0x05,0x07
+VPAD_BUTTON_DPAD_Neutral    =   0x05,0x08
+
+PAD_COUNT                   =   0x01


### PR DESCRIPTION
Tested via https://nondebug.github.io/webhid-explorer/ for HID values

Tested on Pokemon Mystery Dungeon: Explorers of Sky and Yu-Gi-Oh! World Championship 2008 NDS VC. Inputs seem to work without any issue. Controller was set to PS4 mode for testing.